### PR TITLE
Store active watches in the tree

### DIFF
--- a/server/connection.ml
+++ b/server/connection.ml
@@ -26,18 +26,27 @@ end
 type t = {
   uri: Uri.t;
   domid: int;
+  index: int;
   mutable perms: Perms.t;
 }
 
 let all = Hashtbl.create 7
 
+let next_index =
+  let next = ref 0 in
+  fun () ->
+    let this = !next in
+    incr next;
+    this
+
 let create (uri, domid) =
+  let index = next_index () in
   let perms = Perms.of_domain domid in
-  let c = { uri; domid; perms } in
+  let c = { index; uri; domid; perms } in
   Hashtbl.replace all uri c;
   return c
 
-let index _ = -1
+let index t = t.index
 
 let perms t = t.perms
 

--- a/server/xirmin.ml
+++ b/server/xirmin.ml
@@ -269,7 +269,7 @@ let make ?(prefer_merge=true) config db_m =
           Lwt_list.iter_s
             (fun key ->
               info "Watchevent (updated): %s/%s" (Protocol.Path.to_string path) (String.concat "/" key);
-              callback_fn (Protocol.Path.of_string_list key)
+              callback_fn (Protocol.Path.(concat path (of_string_list key)));
             ) (KeySet.fold (fun elt acc -> elt :: acc) all [])
         | `Removed ((_, a)) ->
           ls_lR a []
@@ -277,7 +277,7 @@ let make ?(prefer_merge=true) config db_m =
           Lwt_list.iter_s
             (fun key ->
               info "Watchevent (removed): %s/%s" (Protocol.Path.to_string path) (String.concat "/" key);
-              callback_fn (Protocol.Path.of_string_list key);
+              callback_fn (Protocol.Path.(concat path (of_string_list key)));
             ) (KeySet.fold (fun elt acc -> elt :: acc) all [])
         | `Added ((_, a)) ->
           ls_lR a []


### PR DESCRIPTION
This makes it easier to debug watch problems, plus it prepares the
way for persisting watch registrations across restarts.

Signed-off-by: David Scott <dave.scott@citrix.com>