### PR TITLE
Added a run of 'apt-get update' to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM unikernel/mirage
 COPY opam /src/opam
+RUN sudo apt-get update
 RUN opam install depext -y
 RUN opam pin add ocaml-xenstore-server /src -n
 RUN opam depext ocaml-xenstore-server -y


### PR DESCRIPTION
Hello,

When using docker (`docker build -t xenstore .`), I noticed that some debian packages are needed and automatically downloaded through `opam install depext -y`. However `apt-get` is out of sync , and the whole `docker build` command fails as the packages cannot be downloaded.

The solution is very simple, I added a call to `apt-get update` in the docker file.

Thank you,

Pierre
